### PR TITLE
ENH: Fix for list count=1 edge cases where list is generated in other…

### DIFF
--- a/src/Api/DefaultDashboardProvider.php
+++ b/src/Api/DefaultDashboardProvider.php
@@ -271,6 +271,13 @@ class DefaultDashboardProvider implements DashboardWelcomeQuicklinksProvider
                             $objectCount = $list->count();
                             if ($objectCount === 1) {
                                 $obj = $list->first();
+                                if ($obj && $obj->hasMethod('CMSEditLink')) {
+                                    $link = $obj->CMSEditLink();
+                                    if ($link) {
+                                        DashboardWelcomeQuicklinks::add_link($groupCode, DashboardWelcomeQuicklinks::get_base_phrase('edit') . ' ' . $model::singleton()->i18n_singular_name(), $link);
+                                        continue;
+                                    }
+                                }
                             }
 
                             $link = '';

--- a/src/Api/DefaultDashboardProvider.php
+++ b/src/Api/DefaultDashboardProvider.php
@@ -270,7 +270,14 @@ class DefaultDashboardProvider implements DashboardWelcomeQuicklinksProvider
                             }
                             $objectCount = $list->count();
                             if ($objectCount === 1) {
-                                $obj = $list->first();
+                                $baseTable = Injector::inst()->get($model)->baseTable();
+                                $obj = DataObject::get_one($model, [$baseTable . '.ClassName' => $model]);
+                                if (! $obj) {
+                                    $obj = DataObject::get_one($model);
+                                }
+                                if (! $obj) {
+                                    $obj = $list->first();
+                                }
                                 if ($obj && $obj->hasMethod('CMSEditLink')) {
                                     $link = $obj->CMSEditLink();
                                     if ($link) {

--- a/src/Api/DefaultDashboardProvider.php
+++ b/src/Api/DefaultDashboardProvider.php
@@ -270,18 +270,7 @@ class DefaultDashboardProvider implements DashboardWelcomeQuicklinksProvider
                             }
                             $objectCount = $list->count();
                             if ($objectCount === 1) {
-                                $baseTable = Injector::inst()->get($model)->baseTable();
-                                $obj = DataObject::get_one($model, [$baseTable . '.ClassName' => $model]);
-                                if (! $obj) {
-                                    $obj = DataObject::get_one($model);
-                                }
-                                if ($obj && $obj->hasMethod('CMSEditLink')) {
-                                    $link = $obj->CMSEditLink();
-                                    if ($link) {
-                                        DashboardWelcomeQuicklinks::add_link($groupCode, DashboardWelcomeQuicklinks::get_base_phrase('edit') . ' ' . $model::singleton()->i18n_singular_name(), $link);
-                                        continue;
-                                    }
-                                }
+                                $obj = $list->first();
                             }
 
                             $link = '';


### PR DESCRIPTION
Just grab the object from the list itself if that's what we're using. This accounts for some weird edge cases, like when the list in the model admin is created by an overwritten function that might return different results to a count of that class in the database.